### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/nucosen/nucosen.py
+++ b/src/nucosen/nucosen.py
@@ -146,7 +146,12 @@ def run():
                     logger.warning(f"クッキーファイルが無効です: {e}")
                     logger.info("ユーザー名/パスワードで再度ログインします")
                     if "" in logininfo:
-                        getLogger(__name__).info("現在のログイン情報: {0}".format(str(logininfo)))
+                        getLogger(__name__).info(
+                            "現在のログイン情報: NICO_ID設定済み=%s, NICO_PW設定済み=%s, NICO_TFA設定済み=%s",
+                            bool(logininfo[0]),
+                            bool(logininfo[1]),
+                            bool(logininfo[2]),
+                        )
                         raise Exception("V00 ログイン情報が不十分です。現在の情報はinfoに出力済み。")
                     session = sessionCookie.Session(*logininfo)
                     session.login()
@@ -158,13 +163,23 @@ def run():
             else:
                 logger.debug(f"クッキーファイルが指定されていますが存在しません: {cookie_file}")
                 if "" in logininfo:
-                    getLogger(__name__).info("現在のログイン情報: {0}".format(str(logininfo)))
+                    getLogger(__name__).info(
+                        "現在のログイン情報: NICO_ID設定済み=%s, NICO_PW設定済み=%s, NICO_TFA設定済み=%s",
+                        bool(logininfo[0]),
+                        bool(logininfo[1]),
+                        bool(logininfo[2]),
+                    )
                     raise Exception("V00 ログイン情報が不十分です。現在の情報はinfoに出力済み。")
                 session = sessionCookie.Session(*logininfo)
                 session.login()
         else:
             if "" in logininfo:
-                getLogger(__name__).info("現在のログイン情報: {0}".format(str(logininfo)))
+                getLogger(__name__).info(
+                    "現在のログイン情報: NICO_ID設定済み=%s, NICO_PW設定済み=%s, NICO_TFA設定済み=%s",
+                    bool(logininfo[0]),
+                    bool(logininfo[1]),
+                    bool(logininfo[2]),
+                )
                 raise Exception("V00 ログイン情報が不十分です。現在の情報はinfoに出力済み。")
             session = sessionCookie.Session(*logininfo)
             session.login()


### PR DESCRIPTION
Potential fix for [https://github.com/komatti365/broadcast/security/code-scanning/3](https://github.com/komatti365/broadcast/security/code-scanning/3)

Do not log raw `logininfo`. Replace the sensitive log message with a safe diagnostic that only reports whether each required field is present, without printing values.

Best fix (single approach, no behavior change): in `src/nucosen/nucosen.py`, replace each `getLogger(__name__).info("現在のログイン情報: {0}".format(str(logininfo)))` with a redacted/presence-only message derived from `logininfo` booleans. This preserves troubleshooting utility (which fields are missing) while preventing credential disclosure.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
