### PR TITLE
Cookieベースの認証方法が難しそうなので機能を無効化

### DIFF
--- a/src/nucosen/nucosen.py
+++ b/src/nucosen/nucosen.py
@@ -299,10 +299,10 @@ def run():
             logger.info("放送の準備が整いました: {0}".format(currentLiveId))
             
             # コメントリクエスト監視の開始
-            if watcher is not None:
-                watcher.stop()
-            watcher = comment.CommentWatcher(session, database, currentLiveId)
-            watcher.start()
+            # if watcher is not None:
+            #     watcher.stop()
+            # watcher = comment.CommentWatcher(session, database, currentLiveId)
+            # watcher.start()
             
             is_first_video = (currentQuote is None) and is_fresh_frame
             is_fresh_frame = False


### PR DESCRIPTION
**目的と概要**
Cookieベースの認証方法が難しそうなので機能を完全に無効化

**変更点・修正箇所**
nucosen.py

**影響範囲**


**実施したテストと結果**


**関連Issue**

**追加情報**
tools_apiはCookieからの認証しか受け入れなくて、comment_apiはOAuthからの認証を受け入れない。
ヘッドレス環境での稼働は厳しいと判断。
やはり当初の予定通りOAuth認証で稼働する別クライアントを準備したほうがいいかもしれない